### PR TITLE
Use vscode.open instead of openExternal

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -13,7 +13,7 @@ export const loginCommand: Command = {
   action(context) {
     return async () => {
       const openURL = await generateURL(context);
-      vscode.env.openExternal(vscode.Uri.parse(openURL));
+      vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(openURL).toString(true));
     };
   },
 };


### PR DESCRIPTION
`openExternal` is encoding the URL parameters twice. Seems like this is a [known issue](https://github.com/microsoft/vscode/issues/76606). Even though it's closed, there's been many regressions and other issues with the same problem has been open.

A solution is to use the `vscode.open` command instead. With this we are sure the URL is opened as is, without extra manipulation.