### PR TITLE
Add a "commandId" option to continue the flow after login

### DIFF
--- a/src/AuthUriHandler.ts
+++ b/src/AuthUriHandler.ts
@@ -27,5 +27,10 @@ export class AuthUriHandler implements vscode.UriHandler {
     } catch {
       vscode.window.showErrorMessage("Can't decrypt the apiKey");
     }
+
+    const commandId = searchParams.get("commandId");
+    if (commandId) {
+      vscode.commands.executeCommand(`xata.${commandId}`);
+    }
   }
 }

--- a/src/commands/initWorkspace.ts
+++ b/src/commands/initWorkspace.ts
@@ -24,7 +24,11 @@ export const initWorkspaceCommand: StandAloneCommand<
   action(context, refresh, jsonSchemaProvider) {
     return async (item) => {
       if (!(await context.getToken())) {
-        await loginCommand.action(context, refresh, jsonSchemaProvider)();
+        await loginCommand.action(
+          context,
+          refresh,
+          jsonSchemaProvider
+        )("initWorkspace");
       }
 
       let workspaceFolder: vscode.WorkspaceFolder;

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -6,14 +6,18 @@ import { Context } from "../context";
 /**
  * Command to login through the UI.
  */
-export const loginCommand: Command = {
+export const loginCommand: Command<string> = {
   id: "login",
   type: "global",
   inPalette: true,
   action(context) {
-    return async () => {
+    return async (commandId?: string) => {
       const openURL = await generateURL(context);
-      vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(openURL).toString(true));
+      vscode.commands.executeCommand(
+        "vscode.open",
+        vscode.Uri.parse(openURL).toString(true) +
+          (commandId ? encodeURIComponent(`&commandId=${commandId}`) : "")
+      );
     };
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export type RefreshAction = (scope?: "explorer" | "workspace") => void;
 /**
  * Global VSCode command.
  */
-export type Command = {
+export type Command<T = void> = {
   id: string;
   type: "global";
   /**
@@ -21,7 +21,7 @@ export type Command = {
     context: Context,
     refresh: RefreshAction,
     jsonSchemaProvider: XataJsonSchemaProvider
-  ) => () => void;
+  ) => (params?: T) => void;
 };
 
 /**


### PR DESCRIPTION
## Usecase

First time a user use the vscode extension, when he click on "Get started" (workspace one) the flow was stopped after login.

Now, the flow will continue after the login.