### PR TITLE
Use `npm` in all CI pipelines

### DIFF
--- a/.github/workflows/ovsx-deploy.yml
+++ b/.github/workflows/ovsx-deploy.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           node-version: 16.13.1
           registry-url: https://registry.npmjs.org/
-      - run: yarn
-      - run: yarn deploy:ovsx -p ${{ secrets.OVSX_ACCESS_TOKEN }}
+      - run: npm ci
+      - run: npm run deploy:ovsx -p ${{ secrets.OVSX_ACCESS_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16.13.1
-      - run: npm install
+      - run: npm ci
       - run: npm test

--- a/.github/workflows/vscode-deploy.yml
+++ b/.github/workflows/vscode-deploy.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: 16.13.1
           registry-url: https://registry.npmjs.org/
-      - run: yarn
-      - run: yarn deploy:vscode
+      - run: npm ci
+      - run: npm run deploy:vscode
         env:
           VSCE_PAT: ${{ secrets.VSCODE_ACCESS_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 node_modules
 .vscode-test/
 *.vsix
+.DS_Store


### PR DESCRIPTION
We are using `npm` locally, but 2 pipelines are using `yarn`, while another is using `npm`.

- [x] All CI uses `npm`
- [x] replaces `npm install` with `npm ci`

---

> ⚠️ Disclaimer: no strong opinion. I picked `npm` because of the `package-lock.json` on root.