### PR TITLE
Fix palette command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+
+- Extension not activated on palette commands (login, loginWithToken, logout)
+
 ## 0.0.2
 
 ### Fixed


### PR DESCRIPTION
## Context

https://github.com/xataio/vscode-extension/issues/47#issuecomment-1193758645

The palette command was not activating the extension, this could lead to a "command not found" error.

Thanks @kostasb for the catch!