### PR TITLE
Feat: Create a Xata branch in a non git environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Added
+
+- Deal with xata branch creation in a non git environment.
+
 ## 0.0.2
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -31,9 +31,13 @@
   ],
   "activationEvents": [
     "onCommand:xata.login",
+    "onCommand:xata.palette.login",
     "onCommand:xata.loginWithToken",
+    "onCommand:xata.palette.loginWithToken",
     "onCommand:xata.logout",
+    "onCommand:xata.palette.logout",
     "onCommand:xata.refresh",
+    "onCommand:xata.palette.refresh",
     "onView:xataExplorer",
     "onView:xataWorkspace",
     "onUri"

--- a/src/commands/createBranch.ts
+++ b/src/commands/createBranch.ts
@@ -3,11 +3,14 @@ import { VSCodeWorkspaceTreeItem } from "../views/treeItems/TreeItem";
 import { TreeItemCommand, WorkspaceNavigationItem } from "../types";
 import { createBranch, getBranchList } from "../xata/xataComponents";
 import { ValidationError } from "../xata/xataFetcher";
+import { validateResourceName } from "../utils";
 
 /**
  * Create a xata branch based on the actual git branch.
  *
  * If the xata branch and the git branch are already in sync, ask for creating a new branch.
+ *
+ * If the workspace doesn't have any git environment, the branching will be handled with the `XATA_BRANCH` env var instead.
  */
 export const createBranchCommand: TreeItemCommand<
   VSCodeWorkspaceTreeItem | WorkspaceNavigationItem
@@ -33,7 +36,7 @@ export const createBranchCommand: TreeItemCommand<
 
       const currentGitBranch = await context.getGitBranch(workspaceFolder.uri);
 
-      if (!config || !currentGitBranch) {
+      if (!config) {
         return;
       }
 
@@ -56,7 +59,25 @@ export const createBranchCommand: TreeItemCommand<
 
       let dbBranchName: string;
 
-      if (config.branch !== currentGitBranch) {
+      if (!currentGitBranch) {
+        const newBranchName = await vscode.window.showInputBox({
+          prompt: "Enter the name of your branch",
+          title: "Branch name",
+          validateInput: validateResourceName("branch", existingBranches),
+        });
+
+        if (!newBranchName) {
+          return;
+        }
+        await updateXataBranchInDotEnv(workspaceFolder, newBranchName);
+        dbBranchName = `${config.databaseName}:${newBranchName}`;
+        from =
+          existingBranches.length === 1
+            ? existingBranches[0]
+            : await vscode.window.showQuickPick(existingBranches, {
+                title: "Base branch",
+              });
+      } else if (config.branch !== currentGitBranch) {
         dbBranchName = `${config.databaseName}:${currentGitBranch}`;
         from =
           existingBranches.length === 1
@@ -102,3 +123,31 @@ export const createBranchCommand: TreeItemCommand<
     };
   },
 };
+
+async function updateXataBranchInDotEnv(
+  workspaceFolder: vscode.WorkspaceFolder,
+  branchName: string
+) {
+  const envPath =
+    vscode.workspace.getConfiguration().get<string>("xata.envFilePath") ??
+    ".env";
+
+  const envFileRaw = await await vscode.workspace.fs.readFile(
+    vscode.Uri.joinPath(workspaceFolder.uri, envPath)
+  );
+
+  let envFile = envFileRaw.toString();
+  if (envFile.match(/^XATA_BRANCH=/gm)) {
+    envFile = envFile.replace(
+      /^(XATA_BRANCH=)([a-zA-Z0-9_\-~:]+)/gm,
+      `$1${branchName}`
+    );
+  } else {
+    envFile += `${envFile.length ? "\n" : ""}XATA_BRANCH=${branchName}`;
+  }
+
+  await vscode.workspace.fs.writeFile(
+    vscode.Uri.joinPath(workspaceFolder.uri, envPath),
+    Buffer.from(envFile)
+  );
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -214,8 +214,7 @@ export function getContext(extensionContext: ExtensionContext) {
           },
           queryParams: {
             gitBranch:
-              dotenvConfig.XATA_DATABASE_BRANCH ??
-              (await this.getGitBranch(uri)),
+              dotenvConfig.XATA_BRANCH ?? (await this.getGitBranch(uri)),
           },
         });
 


### PR DESCRIPTION
In order to deal with Xata branch creation / navigation in a non git environment. Let's have a fallback using `XATA_BRANCH` if git is not available.

![d076d9a0-285c-4dc7-94bc-5caddac6302c](https://user-images.githubusercontent.com/1761469/180749393-4e3456e0-06f0-45a6-9493-b40db1bba255.gif)


## Related Issue

#40 