### PR TITLE
feat: adding refresh button for table columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,6 +265,11 @@
         "icon": "$(eye)"
       },
       {
+        "command": "xata.refreshData",
+        "title": "Refresh data",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "xata.openInsertRecordsTemplate",
         "title": "Insert records",
         "icon": "$(json)"
@@ -421,6 +426,10 @@
           "when": "false"
         },
         {
+          "command": "xata.refreshData",
+          "when": "false"
+        },
+        {
           "command": "xata.openInsertRecordsTemplate",
           "when": "false"
         },
@@ -437,6 +446,16 @@
         },
         {
           "command": "xata.addColumn",
+          "when": "view == xataProject && viewItem == table",
+          "group": "inline"
+        },
+        {
+          "command": "xata.refreshData",
+          "when": "view == xataExplorer && viewItem == table",
+          "group": "inline"
+        },
+        {
+          "command": "xata.refreshData",
           "when": "view == xataProject && viewItem == table",
           "group": "inline"
         },

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -21,5 +21,6 @@ export { addTableCommand } from "./addTable";
 export { deleteTableCommand } from "./deleteTable";
 export { renameTableCommand } from "./renameTable";
 export { previewDataCommand } from "./previewData";
+export { refrshDataCommand } from "./refreshData";
 export { openInsertRecordsTemplateCommand } from "./openInsertRecordsTemplate";
 export { createBranchCommand } from "./createBranch";

--- a/src/commands/previewData.ts
+++ b/src/commands/previewData.ts
@@ -33,12 +33,14 @@ export const previewDataCommand = createTreeItemCommand({
           tableName: tableTreeItem.table.name,
         },
       };
+
       const schema = await getTableSchema(params);
-      const table = await queryTable(params);
 
       if (!schema.success) {
         throw new Error(schema.error.payload.message);
       }
+
+      const table = await queryTable(params);
 
       if (!table.success) {
         throw new Error(table.error.payload.message);

--- a/src/commands/refreshData.ts
+++ b/src/commands/refreshData.ts
@@ -1,0 +1,22 @@
+import { createTreeItemCommand } from "../types";
+
+export const refrshDataCommand = createTreeItemCommand({
+  id: "refreshData",
+  title: "Refresh data",
+  contexts: [
+    {
+      item: "table",
+      view: "xataExplorer",
+      group: "inline",
+    },
+    {
+      item: "table",
+      view: "xataProject",
+      group: "inline",
+    },
+  ],
+  icon: "refresh",
+  action: (_, refresh) => {
+    return () => refresh();
+  },
+});


### PR DESCRIPTION
Hi, thanks for this cool project :)

## Description

When we change the columns of a table (renaming, deleting, or adding a new one), the web version of the application immediately updates, but this is not the case for the VSCode-extension plugin.

A simple solution would be to add a refresh button to the table's column listing.

**Would you like to see this proposed solution working?** https://share.cleanshot.com/k9T73T

----

**Update:** My second commit is actually not part of the implementation, but I guess we can use the same space to change that 🧨