### PR TITLE
fix: Fix staging environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## 0.4.4
+
+- Fix extension working against staging
+- Add analytics headers
+- Fix underscore in database url
+
 ## 0.4.1
 
 - Fix init database

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xata",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xata",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xata",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xata",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@vscode/codicons": "^0.0.29",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "preview": true,
   "description": "Manage your Xata database from VS Code",
   "publisher": "xata",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "scripts": {
     "vscode:prepublish": "npm run build",
     "lint": "eslint src --ext ts",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "preview": true,
   "description": "Manage your Xata database from VS Code",
   "publisher": "xata",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "scripts": {
     "vscode:prepublish": "npm run build",
     "lint": "eslint src --ext ts",

--- a/src/commands/addBranch.ts
+++ b/src/commands/addBranch.ts
@@ -23,6 +23,7 @@ export const addBranchCommand = createTreeItemCommand({
   action: (context, refresh) => {
     return async (databaseTreeItem) => {
       const branchList = await getBranchList({
+        baseUrl: databaseTreeItem.baseUrl,
         workspaceId: databaseTreeItem.workspaceId,
         regionId: databaseTreeItem.regionId,
         context: context,

--- a/src/commands/addColumn.ts
+++ b/src/commands/addColumn.ts
@@ -65,6 +65,7 @@ export const addColumnCommand = createTreeItemCommand({
 
       if (type === "link") {
         const branchDetails = await getBranchDetails({
+          baseUrl: tableTreeItem.baseUrl,
           workspaceId: tableTreeItem.workspaceId,
           regionId: tableTreeItem.regionId,
           token: tableTreeItem.scope?.token,
@@ -193,8 +194,10 @@ export const addColumnCommand = createTreeItemCommand({
 
       try {
         await addTableColumn({
+          baseUrl: tableTreeItem.baseUrl,
           workspaceId: tableTreeItem.workspaceId,
           regionId: tableTreeItem.regionId,
+          token: tableTreeItem.scope?.token,
           context,
           body: {
             type,

--- a/src/commands/addTable.ts
+++ b/src/commands/addTable.ts
@@ -27,6 +27,7 @@ export const addTableCommand = createTreeItemCommand({
   ],
   action: (context, refresh) => {
     return async (treeItem) => {
+      let baseUrl: string | undefined;
       let regionId = "";
       let workspaceId = "";
       let dbBranchName = "";
@@ -48,6 +49,7 @@ export const addTableCommand = createTreeItemCommand({
           return;
         }
 
+        baseUrl = config.baseUrl;
         regionId = config.regionId;
         workspaceId = config.workspaceId;
         dbBranchName = `${config.databaseName}:${config.branch}`;
@@ -60,17 +62,20 @@ export const addTableCommand = createTreeItemCommand({
         if (!config) {
           return;
         }
+        baseUrl = config.baseUrl;
         regionId = config.regionId;
         workspaceId = config.workspaceId;
         dbBranchName = `${config.databaseName}:${config.branch}`;
         token = config.apiKey;
       } else {
+        baseUrl = treeItem.baseUrl;
         regionId = treeItem.regionId;
         workspaceId = treeItem.workspaceId;
         dbBranchName = `${treeItem.databaseName}:${treeItem.branchName}`;
       }
 
       const branchDetails = await getBranchDetails({
+        baseUrl,
         regionId,
         workspaceId,
         context,
@@ -99,6 +104,7 @@ export const addTableCommand = createTreeItemCommand({
 
       try {
         await createTable({
+          baseUrl,
           workspaceId,
           regionId,
           context,

--- a/src/commands/createBranch.ts
+++ b/src/commands/createBranch.ts
@@ -49,6 +49,7 @@ export const createBranchCommand = createTreeItemCommand({
       }
 
       const branchList = await getBranchList({
+        baseUrl: config.baseUrl,
         workspaceId: config.workspaceId,
         regionId: config.regionId,
         token: config.apiKey,
@@ -107,6 +108,7 @@ export const createBranchCommand = createTreeItemCommand({
 
       try {
         await createBranch({
+          baseUrl: config.baseUrl,
           workspaceId: config.workspaceId,
           regionId: config.regionId,
           token: config.apiKey,

--- a/src/commands/deleteBranch.ts
+++ b/src/commands/deleteBranch.ts
@@ -24,6 +24,7 @@ export const deleteBranchCommand = createTreeItemCommand({
       }
 
       await deleteBranch({
+        baseUrl: branchTreeItem.baseUrl,
         workspaceId: branchTreeItem.workspaceId,
         regionId: branchTreeItem.regionId,
         context,

--- a/src/commands/deleteColumn.ts
+++ b/src/commands/deleteColumn.ts
@@ -33,6 +33,7 @@ export const deleteColumnCommand = createTreeItemCommand({
       }
 
       await deleteColumn({
+        baseUrl: columnTreeItem.baseUrl,
         workspaceId: columnTreeItem.workspaceId,
         regionId: columnTreeItem.regionId,
         token: columnTreeItem.scope?.token,

--- a/src/commands/deleteTable.ts
+++ b/src/commands/deleteTable.ts
@@ -35,6 +35,7 @@ export const deleteTableCommand = createTreeItemCommand({
       }
 
       await deleteTable({
+        baseUrl: tableTreeItem.baseUrl,
         workspaceId: tableTreeItem.workspaceId,
         regionId: tableTreeItem.regionId,
         token: tableTreeItem.scope?.token,

--- a/src/commands/insertRecords.ts
+++ b/src/commands/insertRecords.ts
@@ -79,6 +79,7 @@ export const insertRecordsCommand: Command = {
 
         try {
           const res = await bulkInsertTableRecords({
+            baseUrl: config?.baseUrl,
             workspaceId,
             regionId,
             token: config?.apiKey,
@@ -115,6 +116,7 @@ export const insertRecordsCommand: Command = {
                       vscode.TreeItemCollapsibleState.Collapsed,
                       {
                         workspaceId,
+                        baseUrl: config?.baseUrl,
                         regionId,
                         databaseName,
                         branchName,

--- a/src/commands/previewData.ts
+++ b/src/commands/previewData.ts
@@ -26,6 +26,7 @@ export const previewDataCommand = createTreeItemCommand({
   action: (context) => {
     return async (tableTreeItem) => {
       const params = {
+        baseUrl: tableTreeItem.baseUrl,
         workspaceId: tableTreeItem.workspaceId,
         regionId: tableTreeItem.regionId,
         token: tableTreeItem.scope?.token,

--- a/src/commands/renameColumn.ts
+++ b/src/commands/renameColumn.ts
@@ -33,6 +33,7 @@ export const renameColumnCommand = createTreeItemCommand({
 
       try {
         await updateColumn({
+          baseUrl: columnTreeItem.baseUrl,
           workspaceId: columnTreeItem.workspaceId,
           regionId: columnTreeItem.regionId,
           token: columnTreeItem.scope?.token,

--- a/src/commands/renameTable.ts
+++ b/src/commands/renameTable.ts
@@ -17,6 +17,8 @@ export const renameTableCommand = createTreeItemCommand({
   action: (context, refresh, jsonSchemaProvider) => {
     return async (tableTreeItem) => {
       const branchDetails = await getBranchDetails({
+        baseUrl: tableTreeItem.baseUrl,
+        token: tableTreeItem.scope?.token,
         workspaceId: tableTreeItem.workspaceId,
         regionId: tableTreeItem.regionId,
         context: context,
@@ -45,6 +47,7 @@ export const renameTableCommand = createTreeItemCommand({
 
       try {
         await updateTable({
+          baseUrl: tableTreeItem.baseUrl,
           workspaceId: tableTreeItem.workspaceId,
           regionId: tableTreeItem.regionId,
           token: tableTreeItem.scope?.token,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { getFlattenColumns, validateResourceName } from "./utils";
+import {
+  getFlattenColumns,
+  DatabaseUrl,
+  parseDatabaseUrl,
+  validateResourceName,
+} from "./utils";
 
 vi.mock("vscode", () => ({}));
 
@@ -41,5 +46,76 @@ describe("getFlattenColumns", () => {
         },
       ])
     ).toEqual(["email", "address.number", "address.line1", "address.line2"]);
+  });
+});
+
+describe("parseUrl", () => {
+  it("should parse production url", () => {
+    const expected: DatabaseUrl = {
+      regionId: "eu-west-1",
+      databaseName: "default-value",
+      workspaceId: "demo-07kttr",
+      baseUrl: "https://demo-07kttr.eu-west-1.xatabase.co",
+    };
+
+    expect(
+      parseDatabaseUrl(
+        "https://demo-07kttr.eu-west-1.xatabase.co/db/default-value"
+      )
+    ).toEqual(expected);
+  });
+  it("should parse production url (without region)", () => {
+    const expected: DatabaseUrl = {
+      regionId: "eu-west-1",
+      databaseName: "default-value",
+      workspaceId: "demo-07kttr",
+      baseUrl: "https://demo-07kttr.xatabase.co",
+    };
+
+    expect(
+      parseDatabaseUrl("https://demo-07kttr.xatabase.co/db/default-value")
+    ).toEqual(expected);
+  });
+  it("should parse staging url", () => {
+    const expected: DatabaseUrl = {
+      regionId: "eu-west-1",
+      databaseName: "default-value",
+      workspaceId: "demo-07kttr",
+      baseUrl: "https://demo-07kttr.staging.eu-west-1.xatabase.co",
+    };
+
+    expect(
+      parseDatabaseUrl(
+        "https://demo-07kttr.staging.eu-west-1.xatabase.co/db/default-value"
+      )
+    ).toEqual(expected);
+  });
+
+  it("should parse staging url (without region)", () => {
+    const expected: DatabaseUrl = {
+      regionId: "eu-west-1",
+      databaseName: "default-value",
+      workspaceId: "demo-07kttr",
+      baseUrl: "https://demo-07kttr.staging.xatabase.co",
+    };
+
+    expect(
+      parseDatabaseUrl(
+        "https://demo-07kttr.staging.xatabase.co/db/default-value"
+      )
+    ).toEqual(expected);
+  });
+
+  it("should parse localhost url", () => {
+    const expected: DatabaseUrl = {
+      regionId: "eu-west-1",
+      databaseName: "default-value",
+      workspaceId: "demo-07kttr",
+      baseUrl: "https://demo-07kttr.localhost:1337",
+    };
+
+    expect(
+      parseDatabaseUrl("https://demo-07kttr.localhost:1337/db/default-value")
+    ).toEqual(expected);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -63,3 +63,43 @@ export function getFlattenColumns(
 
   return entries;
 }
+
+export type DatabaseUrl = {
+  regionId: string;
+  databaseName: string;
+  workspaceId: string;
+  baseUrl: string;
+};
+
+export function parseDatabaseUrl(databaseURL: string): DatabaseUrl {
+  const { pathname, origin: baseUrl, host } = new URL(databaseURL);
+  const urlChunks = host.split(".");
+  const databaseName = pathname.split("/")[2];
+  const workspaceId = host.split(".")[0];
+
+  // List of things that could be in the url but not a region
+  const notARegion = [
+    "xata",
+    "staging",
+    "localhost",
+    "xatabase",
+    "io",
+    "co",
+    "com",
+  ];
+
+  let regionId = "eu-west-1";
+
+  if (urlChunks[2] && !notARegion.includes(urlChunks[2])) {
+    regionId = urlChunks[2];
+  } else if (urlChunks[3] && !notARegion.includes(urlChunks[3])) {
+    regionId = urlChunks[3];
+  }
+
+  return {
+    baseUrl,
+    databaseName,
+    workspaceId,
+    regionId,
+  };
+}

--- a/src/views/treeItems/TreeItem.ts
+++ b/src/views/treeItems/TreeItem.ts
@@ -7,17 +7,20 @@ import type { GetWorkspacesListResponse } from "../../xataCore/xataCoreComponent
 export type Workspace = GetWorkspacesListResponse["workspaces"][-1];
 
 type Database = Required<CoreSchema.ListDatabasesResponse>["databases"][-1] & {
+  baseUrl?: string;
   workspaceId: string;
   regionId: string;
 };
 
 type Branch = WorspaceSchema.Branch & {
+  baseUrl?: string;
   workspaceId: string;
   regionId: string;
   databaseName: string;
 };
 
 type Table = WorspaceSchema.Table & {
+  baseUrl?: string;
   workspaceId: string;
   regionId: string;
   databaseName: string;
@@ -25,6 +28,7 @@ type Table = WorspaceSchema.Table & {
 };
 
 type Column = WorspaceSchema.Column & {
+  baseUrl?: string;
   workspaceId: string;
   regionId: string;
   databaseName: string;
@@ -48,6 +52,7 @@ export class WorkspaceTreeItem extends vscode.TreeItem {
 export class DatabaseTreeItem extends vscode.TreeItem {
   contextValue = "database" as const;
   iconPath = new vscode.ThemeIcon("database");
+  baseUrl?: string;
   workspaceId: string;
   regionId: string;
 
@@ -59,6 +64,7 @@ export class DatabaseTreeItem extends vscode.TreeItem {
   ) {
     super(label, collapsibleState);
 
+    this.baseUrl = database.baseUrl;
     this.workspaceId = database.workspaceId;
     this.regionId = database.regionId;
     this.description = database.regionId;
@@ -73,6 +79,7 @@ export class DatabaseTreeItem extends vscode.TreeItem {
 export class BranchTreeItem extends vscode.TreeItem {
   contextValue = "branch" as const;
   iconPath = new vscode.ThemeIcon("source-control");
+  baseUrl?: string;
   workspaceId: string;
   regionId: string;
   databaseName: string;
@@ -85,6 +92,7 @@ export class BranchTreeItem extends vscode.TreeItem {
   ) {
     super(label, collapsibleState);
 
+    this.baseUrl = branch.baseUrl;
     this.workspaceId = branch.workspaceId;
     this.regionId = branch.regionId;
     this.databaseName = branch.databaseName;
@@ -103,6 +111,7 @@ export class BranchTreeItem extends vscode.TreeItem {
 export class TableTreeItem extends vscode.TreeItem {
   contextValue = "table" as const;
   iconPath = new vscode.ThemeIcon("table");
+  baseUrl?: string;
   workspaceId: string;
   regionId: string;
   databaseName: string;
@@ -119,6 +128,7 @@ export class TableTreeItem extends vscode.TreeItem {
   ) {
     super(label, collapsibleState);
 
+    this.baseUrl = table.baseUrl;
     this.workspaceId = table.workspaceId;
     this.regionId = table.regionId;
     this.databaseName = table.databaseName;
@@ -128,6 +138,7 @@ export class TableTreeItem extends vscode.TreeItem {
 
 export class ColumnTreeItem extends vscode.TreeItem {
   contextValue = "column" as const;
+  baseUrl?: string;
   workspaceId: string;
   regionId: string;
   databaseName: string;
@@ -147,6 +158,7 @@ export class ColumnTreeItem extends vscode.TreeItem {
   ) {
     super(label, collapsibleState);
 
+    this.baseUrl = column.baseUrl;
     this.workspaceId = column.workspaceId;
     this.regionId = column.regionId;
     this.databaseName = column.databaseName;

--- a/src/views/treeItems/getColumnTreeItems.ts
+++ b/src/views/treeItems/getColumnTreeItems.ts
@@ -12,6 +12,7 @@ export async function getColumnTreeItems(
   }
 ) {
   const tableSchema = await getTableSchema({
+    baseUrl: element.baseUrl,
     regionId: element.regionId,
     workspaceId: element.workspaceId,
     token: scope?.token,
@@ -38,6 +39,7 @@ export async function getColumnTreeItems(
           : vscode.TreeItemCollapsibleState.None,
         {
           ...column,
+          baseUrl: element.baseUrl,
           workspaceId: element.workspaceId,
           regionId: element.regionId,
           databaseName: element.databaseName,

--- a/src/views/treeItems/getTableTreeItems.ts
+++ b/src/views/treeItems/getTableTreeItems.ts
@@ -9,6 +9,7 @@ export async function getTableTreeItems(
     regionId: string;
     databaseName: string;
     branchName: string;
+    baseUrl?: string;
   },
   context: Context,
   scope?: {
@@ -19,6 +20,7 @@ export async function getTableTreeItems(
   const branchDetails = await getBranchDetails({
     workspaceId: element.workspaceId,
     regionId: element.regionId,
+    baseUrl: element.baseUrl,
     token: scope?.token,
     context: context,
     pathParams: {

--- a/src/views/xataProject.ts
+++ b/src/views/xataProject.ts
@@ -74,6 +74,7 @@ class XataDataProvider implements vscode.TreeDataProvider<TreeItem> {
             regionId: config.regionId,
             databaseName: config.databaseName,
             branchName: config.branch,
+            baseUrl: config.baseUrl,
           },
           this.context,
           {

--- a/src/xataWorkspace/xataWorkspaceFetcher.ts
+++ b/src/xataWorkspace/xataWorkspaceFetcher.ts
@@ -7,6 +7,7 @@ export type XataWorkspaceFetcherExtraProps = {
   silentError?: boolean;
   workspaceId: string;
   regionId: string;
+  baseUrl?: string;
 };
 
 export type ErrorWrapper<TError> = TError;
@@ -44,6 +45,7 @@ export async function xataWorkspaceFetch<
   context,
   workspaceId,
   regionId,
+  baseUrl,
 }: XataWorkspaceFetcherOptions<
   TBody,
   THeaders,
@@ -65,10 +67,12 @@ export async function xataWorkspaceFetch<
       token = await context.getToken();
     }
 
-    const baseUrl = context
-      .getWorkspaceBaseUrl()
-      .replace("{workspaceId}", workspaceId)
-      .replace("{regionId}", regionId);
+    baseUrl =
+      baseUrl ??
+      context
+        .getWorkspaceBaseUrl()
+        .replace("{workspaceId}", workspaceId)
+        .replace("{regionId}", regionId);
 
     const response = await crossFetch(
       `${baseUrl}${resolveUrl(url, queryParams, pathParams)}`,


### PR DESCRIPTION
## Context

When working against staging, since the introduction of region, the vscode extension was not working

## Solution

Parse and use `baseUrl` instead of composing the URL manually. Then if a `databaseURL` is set with `https://{workspaceId}.staging.{regionId}.xatabase.co` the extension will use the correct URL.


## How to test?

* Go to staging  
* Create and paste a token in a `.env` as `XATA_API_KEY` 
* From the code snippet, copy the `databaseURL` into a `.xatarc` file

The vscode extension should point on staging.